### PR TITLE
Remove clearfix class from container

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ title: Help Prospect Heights
           >Food Safety and Coronavirus: A Comprehensive Guide</a
         >
       </p>
-      <div class="flex flex-wrap center cf">
+      <div class="flex flex-wrap center">
         {% for place in site.data.places.open %}
 
         <div class="w-100 w-100-m w-third-ns pa2">


### PR DESCRIPTION
Because this container's using `display: flex` you don't need a clearfix (which you would if you were using floats to stack the grid items instead). Caveat: I've never used tachyons before, so if this came from an example I'm not 100% sure why it's there.

<img width="1228" alt="Screen Shot 2020-03-24 at 2 29 59 PM" src="https://user-images.githubusercontent.com/619997/77463678-5e447980-6ddc-11ea-8d69-2389f3078be0.png">

Fixes #1 