### PR TITLE
Remove `where_exp`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins

--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -1,24 +1,24 @@
-- id: bar
+- name: bar
   display_name: Bar
   category_heading: Bars
-- id: cafe
+- name: cafe
   display_name: Cafe
   category_heading: Cafes
-- id: food
+- name: food
   display_name: Restaurant
   category_heading: Restaurants
-- id: dessert
+- name: dessert
   display_name: Dessert
   category_heading: Desserts
-- id: grocery
+- name: grocery
   display_name: Grocer
   category_heading: Grocers
-- id: service
+- name: service
   display_name: Service
   category_heading: Services
-- id: store
+- name: store
   display_name: Store
   category_heading: Stores
-- id: wine-liquor
+- name: wine-liquor
   display_name: 'Wine & Liquor'
   category_heading: 'Wine & Liquor Stores'

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -1456,16 +1456,6 @@
     instagram: 'https://www.instagram.com/sweetpollynyc/'
   status: open
   url: 'http://www.sweetpollynyc.com'
-- name: Taro Sushi
-  category: food
-  last_updated: 3/16
-  notes: >-
-    Permanently closed. A note on the door says that they intend to open at a
-    new location in the future.
-  social:
-    instagram: 'https://www.instagram.com/tarosushi.bk/'
-  status: permanently closed
-  url: 'https://www.tarosushibrooklyn.com'
 - name: Tom’s Restaurant
   category: food
   last_updated: 3/17

--- a/_includes/category_section.html
+++ b/_includes/category_section.html
@@ -1,7 +1,7 @@
-{% assign cat_items = open_places | where_exp: "item","item.category == include.cat" %}
+{% assign cat_items = places | where: "category", include.cat %}
 
 <h2 class="w-100 f3 f2-ns ttu ttn-ns lh-solid tc light-red mt4">{{ include.heading }}</h2>
 
-{% for place in cat_items %}
+{% for place in cat_items %}{% unless place.status == "closed" %}
  {% include place.html %}
-{% endfor %}
+{% endunless %}{% endfor %}

--- a/index.html
+++ b/index.html
@@ -4,12 +4,11 @@ layout: default
 ---
 
 {% assign places = site.data.places | sort: "name" %}
-{% assign open_places = places | where_exp:"item","item.status == 'open' or item.status == nil" %}
-{% assign closed_places = site.data.places | where:"status","closed" %}
+{% assign closed_places = site.data.places | where: "status", "closed" %}
 
 <div class="flex flex-wrap center pv2 ph2 ph5-ns">
   {% for category in site.data.categories %}
-    {% include category_section.html cat=category.id heading=category.category_heading %}
+    {% include category_section.html cat=category.name heading=category.category_heading %}
   {% endfor %}
 </div>
 
@@ -18,9 +17,9 @@ layout: default
   <h2 class="w-100 f2 lh-solid tc">Full Directory</h2>
   <h3 class="w-100 nt3 f3 lh-copy ttu tc light-red">All Open Businesses</h3>
   <div class="flex flex-wrap">
-  {% for place in open_places %}
+  {% for place in places %}{% unless place.status == "closed" %}
     {% include place_mini.html %}
-  {% endfor %}
+  {% endunless %}{% endfor %}
   </div>
 
   <h3 class="w-100 mt3 f3 lh-copy ttu tc light-red">Temporarily closed 😢</h3>


### PR DESCRIPTION
I broke master when merging because locally I could run Jekyll with the setup I had, but it didn’t translate into what GitHub Pages expected. This adds a Gemfile to get `bundle exec jekyll build` to run locally, so this doesn’t happen again, but more importantly removes the way I was using `where_exp` filtering. I’m now using an `unless` on the status to remove closed venues.

This should get master working again, but if there’s a better future way to do this, I’m game to make additional fixes.

(Also: removed Taro from the list of places.)