### PR TITLE
Summer 2021 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Help Prospect Heights!
 
-**CONTRIBUTIONS WELCOME**, both in terms of content and design/features.
+**CONTRIBUTIONS WELCOME**, both in terms of content and design/features. Start a pull request or create an [issue](https://github.com/irace/prospectheightsbk.com/issues) to help keep this up to date.
 
 This website is built using [Jekyll](https://jekyllrb.com) and [Tachyons](http://tachyons.io) and served using GitHub Pages.
 

--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -1,21 +1,27 @@
+- name: a1
+  heading: 'Neighborhood Organizations'
+  order: 1
 - name: food-drink
   heading: 'Bars & Restaurants'
-  order: 1
+  order: 2
 - name: cafe
   heading: Cafes
-  order: 2
+  order: 3
+- name: deli-bodega
+  heading: Bodegas
+  order: 4
 - name: dessert
   heading: Desserts
-  order: 3
+  order: 5
 - name: grocery
   heading: Grocers
-  order: 4
+  order: 6
 - name: service
   heading: Services
-  order: 5
+  order: 7
 - name: store
   heading: Stores
-  order: 6
+  order: 8
 - name: wine-liquor
   heading: 'Wine & Liquor Stores'
-  order: 7
+  order: 9

--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -13,7 +13,7 @@
 - name: dessert
   heading: Desserts
   order: 5
-- name: grocery
+- name: grocer
   heading: Grocers
   order: 6
 - name: service

--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -7,7 +7,7 @@
 - name: cafe
   heading: Cafes
   order: 3
-- name: deli-bodega
+- name: deli
   heading: Bodegas
   order: 4
 - name: dessert

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -52,17 +52,8 @@
   category: store
   address: 628 Vanderbilt Ave.
   phone: (718) 789-8062
-  hours:
-    - days: Mon - Fri
-      hours: 10AM - 7PM
-      span: 5
-    - days: Sat
-      hours: 10AM - 5PM
-    - days: Sun
-      hours: 11AM - 5PM
-  supports:
-    - Curbside Pickup
-    - Delivery
+  notes: >-
+    Local pet food store, in business for more than 30 years. Offers local delivery.
   social:
     instagram: 'https://www.instagram.com/acmepetfood/'
 
@@ -2523,6 +2514,16 @@
     instagram: 'https://www.instagram.com/theslyrose/'
   url: 'https://www.theslyrose.com'
 
+- name: Smokey Vale
+  address: 575 Vanderbilt Ave.
+  phone: (347) 240-1133
+  category: store
+  notes: >-
+    Black-owned botique, barber shop and gallery space.
+  social:
+    instagram: 'https://www.instagram.com/smokey_vale/'
+  url: 'http://smokeyvale.com'
+
 - name: The Social
   last_updated: 3/24
   address: 816 Washington Ave.
@@ -2532,7 +2533,6 @@
     New ice cream shop coming this summer from the founders of Ample Hills.
   social:
     instagram: 'https://www.instagram.com/thebrooklynicecreamsocial/'
-  
 
 - name: Sofreh
   last_updated: 1/6

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -524,7 +524,7 @@
 
 - name: BKLYN Larder
   last_updated: 1/6
-  category: grocery
+  category: grocer
   address: 228 Flatbush Ave.
   phone: (718) 783-1250
   hours:
@@ -1766,7 +1766,7 @@
 
 - name: Mermaid’s Garden
   last_updated: 1/6
-  category: grocery
+  category: grocer
   address: 644 Vanderbilt Ave.
   phone: (718) 638-1910
   hours: 
@@ -2383,7 +2383,7 @@
 
 - name: Prospect Butcher Co.
   last_updated: 1/6
-  category: grocery
+  category: grocer
   address: 665 Vanderbilt Ave.
   phone: (347) 763-9500
   hours:
@@ -2399,7 +2399,7 @@
 
 - name: R&D Foods
   last_updated: 1/10
-  category: grocery
+  category: grocer
   address: 602 Vanderbilt Ave.
   phone: (347) 915-1196
   hours:

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -1,3 +1,32 @@
+- name: Prospect Heights Neighborhood Development Council
+  category: a1
+  notes: >-
+    “The Prospect Heights Neighborhood Development Council (PHNDC) brings Prospect Heights community members together to build a safer, more just and sustainable neighborhood.”
+  social:
+    instagram: 'https://www.instagram.com/phndc_brooklyn/'
+    facebook: 'https://www.facebook.com/phndc/'
+  url: 'https://www.phndc.org'
+- name: Underhill Open Streets
+  category: a1
+  notes: >-
+    Updates from the organizers of weekday traffic-free Underhill Avenue, supported by PHNDC.
+  social:
+    instagram: 'https://www.instagram.com/underhilloscc/'
+- name: Vanderbilt Open Streets
+  category: a1
+  notes: >-
+    The official website of the traffic-free weekends on Vanderbilt Avenue, supported by PHNDC and NYC DOT’s Open Streets initiative.
+  social:
+    instagram: 'https://www.instagram.com/vanderbiltopenstreets/'
+  url: 'https://vanderbiltavenue.org'
+- name: 'North Flatbush Business Improvement District'
+  category: a1
+  notes: >-
+    A BID that supports the corridor of Flatbush Avenue from Atlantic Avenue to Grand Army Plaza.
+  social:
+    instagram: 'https://www.instagram.com/northflatbushbk/'
+    facebook: 'https://www.facebook.com/northflatbushbk/'
+  url: 'http://www.northflatbushbid.nyc'
 - name: 333 Lounge
   last_updated: 1/6
   category: food-drink

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -2469,7 +2469,6 @@
     instagram: 'https://www.instagram.com/shanes_brooklyn/'
 
 - name: Sharlene’s Bar
-  last_updated: 2/13
   address: 353 Flatbush Ave.
   category: food-drink
   hours:
@@ -2502,12 +2501,12 @@
   url: 'http://sitandwonder.net/index.html'
 
 - name: The Sly Rose
-  last_updated: 3/24
+  status: closed
   address: 663 Washington Ave.
   phone: (929) 554-3064
   category: food-drink
   notes: >-
-    New Italian restaurant run by the folks at Stocked.
+    New Italian restaurant run by the folks at Stocked, currently on a summer hiatus.
   hours:
     - days: Mon - Tue
       hours: Closed
@@ -2629,7 +2628,6 @@
   url: 'http://www.sunshinecobk.com'
 
 - name: Sweet Chick
-  last_updated: 1/6
   category: food-drink
   address: 341 Flatbush Ave.
   phone: (718) 484-7724
@@ -2637,9 +2635,6 @@
     - days: Mon - Sun
       hours: 12 - 10PM
       span: 7
-  notes: >-
-    Serving fried chicken sandwiches and more as
-    <a href="https://www.instagram.com/LILSWEETCHICK/">Lil’ Sweet Chick</a>.
   supports:
     - Outdoor Dining
     - Pickup
@@ -2691,9 +2686,8 @@
   last_updated: 2/12
   category: food-drink
   address: 229 Flatbush Ave.
-  status: closed
   notes: >-
-    New restaurant coming soon by the Morgan's BBQ team in the former Shorty’s space.
+    New restaurant by the Morgan's BBQ team in the former Shorty’s space.
   social:
     instagram: 'https://instagram.com/tinyscantina'
   url: 'https://www.tinyscantina.com/'
@@ -2847,22 +2841,6 @@
     instagram: 'https://instagram.com/vanderbiltwine'
     facebook: 'https://www.facebook.com/VanderbiltWine'
   url: 'https://vanderbilt.wine'
-
-- name: Washington Ave. Cafe
-  last_updated: 1/6
-  category: cafe
-  address: 621 Washington Ave.
-  phone: (718) 230-3734
-  hours:
-    - days: Mon - Sun
-      hours: 5:30AM - 4:00PM
-      span: 7
-  supports:
-    - Pickup
-    - Delivery
-  services:
-    seamless: 'https://www.seamless.com/menu/washington-avenue-cafe-621-washington-ave-brooklyn/900005'
-    grubhub: 'https://www.grubhub.com/restaurant/washington-avenue-cafe-621-washington-ave-brooklyn/900005'
 
 - name: Weather Up
   last_updated: 1/10

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -772,29 +772,6 @@
     facebook: 'https://www.facebook.com/CherylsGlobalSoul'
   url: 'https://www.cherylsglobalsoul.com'
 
-- name: Chick-P
-  last_updated: 1/6
-  category: food-drink
-  address: 490 Bergen St.
-  phone: (718) 783-1525
-  hours:
-    - days: Mon - Sat
-      hours: 11AM - 10PM
-      span: 6
-    - days: Sun
-      hours: 11AM - 9PM
-  notes: >-
-    Get 10% off when ordering directly from their website.
-  services:
-    direct: 'https://eat.9fold.me/index.html#/10955'
-    doordash: 'https://www.doordash.com/store/chick-p-brooklyn-28639/en-US'
-    postmates: 'https://postmates.com/merchant/chick-p-brooklyn'
-    seamless: 'https://www.seamless.com/menu/chick-p-490-bergen-st-brooklyn/262480'
-    grubhub: 'https://www.grubhub.com/restaurant/chick-p-490-bergen-st-brooklyn/262480'
-  social:
-    instagram: 'https://www.instagram.com/chickpbrooklyn/'
-  url: 'https://www.chick-p.com'
-
 - name: Chuko
   last_updated: 1/6
   category: food-drink
@@ -928,17 +905,15 @@
     instagram: 'https://www.instagram.com/dickeys.bk/'
   url: 'https://www.dickeys.com/locations/New-York/Brooklyn/1683-brooklyn'
 
-- name: Dough Studio
-  last_updated: 5/13
-  category: dessert
+- name: Dough
+  last_updated: 7/2
+  category: cafe
+  address: 646 Vanderbilt Ave.
   notes: >-
-    “I started this business to pay for grad school!
-    So if you love cinnamon rolls or pizza, you better try ours.
-    Delivery in Brooklyn 🧡”
+    Recently opened cafe in the former Jocye Bakeshop space.
   social:
-    instagram: 'https://www.instagram.com/doughstudio_/'
-    facebook: 'https://www.facebook.com/Dough-Studio-105988981103219'
-
+    instagram: https://www.instagram.com/doughdoughnuts/
+  
 - name: Doughnut Plant
   last_updated: 1/6
   category: cafe
@@ -1077,13 +1052,23 @@
     instagram: 'https://www.instagram.com/fermentedgrapesbk/'
   url: 'http://www.fermentedgrapes.net'
 
+- name: 'Finn’s Corner'
+  last_updated: 7/2
+  category: food-drink
+  address: 660 Washington Ave.
+  phone: (347) 663-9316
+  social:
+    instagram: 'https://www.instagram.com/finnscornernyc/'
+  url: 'http://www.finnscornernyc.com'
+
 - name: Flatbush Counter
-  last_updated: 3/24
+  last_updated: 7/2
   category: food-drink
   address: 295 Flatbush Ave.
-  status: closed
   notes: >-
-    Coming soon in the former Rose’s space.
+    New fast-casual concept from a former
+    Flabush Farm and Bar(n) chef
+    in the former Rose’s space.
   social:
     instagram: 'https://www.instagram.com/flatbushcounter/'
   url: 'https://www.flatbushcounter.com'
@@ -1431,6 +1416,18 @@
     instagram: 'https://www.instagram.com/kimchigrill/'
   url: 'https://www.kimchigrill.com'
 
+- name: Kit
+  last_updated: 7/2
+  category: food-drink
+  address: 657 Washington Ave.
+  notes: >-
+    New queer-focused cafe and shop in the former MeMe’s Diner space.
+  social:
+    instagram: 'https://www.instagram.com/kit_bklyn/'
+  services:
+    toast: 'https://www.toasttab.com/kitbklyn/v3'
+
+
 - name: Kombit Bar and Restaurant
   last_updated: 1/23
   category: food-drink
@@ -1471,30 +1468,6 @@
   social:
     instagram: 'https://www.instagram.com/konditori/'
   url: https://konditori.com/our-locations/prospect-heights/
-
-- name: Kulushkat
-  last_updated: 1/6
-  category: food-drink
-  address: 446C Dean St.
-  phone: (347) 799-1972
-  hours:
-    - days: Mon
-      hours: Closed
-    - days: Tue - Fri
-      hours: 11AM - 10PM
-      span: 4
-    - days: Sat - Sun
-      hours: 12 - 10PM
-      span: 2
-  supports:
-    - Outdoor Dining
-    - Pickup
-    - Delivery
-  services:
-    chownow: 'https://direct.chownow.com/order/8549/locations/11540'
-  social:
-    instagram: 'https://www.instagram.com/kulushkat/'
-  url: 'https://kulushkat.com'
 
 - name: LaLou
   last_updated: 2/13

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -6,6 +6,7 @@
     instagram: 'https://www.instagram.com/phndc_brooklyn/'
     facebook: 'https://www.facebook.com/phndc/'
   url: 'https://www.phndc.org'
+
 - name: Underhill Open Streets
   category: a1
   notes: >-
@@ -1452,7 +1453,7 @@
   category: food-drink
   address: 611 Bergen Ave.
   notes: >-
-    First brick-and-mortar retail location for King David Tacos, serving Austin-style breakfast tacos. Check their Instagram for early sell-outs.
+    First brick-and-mortar retail location serving Austin-style breakfast tacos. Check their Instagram in case of early sell-outs.
   social:
     instagram: 'https://www.instagram.com/kingdavidtacos/'
     facebook: 'https://www.facebook.com/kingdavidtacos'
@@ -2162,22 +2163,11 @@
   url: 'http://www.oldebrooklynbagelshop.com'
 
 - name: Olmsted
-  last_updated: 1/13
   category: food-drink
   address: 659 Vanderbilt Ave.
   phone: (718) 552-2610
-  hours:
-    - days: Mon - Tue
-      hours: Closed
-      span: 2
-    - days: Wed - Fri
-      hours: 5 - 10PM
-      span: 3
-    - days: Sat - Sun
-      hours: 12 - 10PM
-      span: 2
   notes: >-
-    Trading Post and Cozy Cottage have reopened. Sat & Sun lunch until 3PM, dinner at 5PM
+    Trading Post is closing in a few short weeks to make way for restarting their private dining room.
   links:
     - title: Staff Relief Fund
       url: 'https://www.gofundme.com/f/olmsted-amp-maison-yaki-staff-disaster-relief-fund'
@@ -2613,7 +2603,7 @@
     - Pickup
     - Delivery
   services:
-    chownow: 'https://direct.chownow.com/order/18160/locations/26048'
+    toast: 'https://www.toasttab.com/stocked-cafe-burgers/v3'
   social:
     instagram: 'https://www.instagram.com/stockedbrooklyn/'
   url: 'https://www.stockedbrooklyn.com'

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -447,6 +447,14 @@
     instagram: 'https://www.instagram.com/biltbar/'
     facebook: 'https://www.facebook.com/pages/category/Lounge/Bilt-Bar-100153434688553/'
 
+- name: BK Lobster
+  category: food-drink
+  address: 643 Vanderbilt Ave.
+  notes: >-
+    Coming soon.
+  social:
+    instagram: 'https://www.instagram.com/bklobsterprospectheights/'
+
 - name: BKLYN Clay
   last_updated: 1/6
   category: service
@@ -926,7 +934,6 @@
   url: 'https://www.dickeys.com/locations/New-York/Brooklyn/1683-brooklyn'
 
 - name: Dough
-  last_updated: 7/2
   category: cafe
   address: 646 Vanderbilt Ave.
   notes: >-
@@ -935,21 +942,9 @@
     instagram: https://www.instagram.com/doughdoughnuts/
   
 - name: Doughnut Plant
-  last_updated: 1/6
   category: cafe
   address: 245 Flatbush Ave.
   phone: (212) 505-3700,245
-  hours:
-    - days: Mon - Tue
-      hours: Closed
-      span: 2
-    - days: Wed - Sun
-      hours: 8AM - 4PM
-      span: 5
-  supports:
-    - Pickup
-    - Delivery
-    - Nationwide Shipping
   links:
     - title: Gift Cards
       url: 'https://www.doughnutplant.com/store/gift-cards/'
@@ -1171,11 +1166,20 @@
       hours: 12 - 9PM (Coffee & Pastries 8AM - 12PM)
       span: 7
   notes: >-
-    Beer to-go window and outdoor seating available. Check website and Untappd for inventory.
+    Beer to-go window along with seating indoors and outdoors. Check website and Untappd for inventory.
   social:
     instagram: 'https://www.instagram.com/goldstarbeercounter/'
     untappd: 'https://untappd.com/v/gold-star-beer-counter/3171446'
   url: 'http://goldstarbeercounter.com'
+
+- name: Good Reps
+  category: service
+  address: 639 Vanderbilt Ave.
+  notes: >-
+    Physical therapy by appointment.
+  social:
+    instagram: https://www.instagram.com/goodrepsphysicaltherapy/
+  url: 'https://goodrepspt.janeapp.com'
 
 - name: Gorilla Coffee
   last_updated: 1/6
@@ -1194,13 +1198,6 @@
   social:
     instagram: 'https://www.instagram.com/gorillacoffee/'
   url: 'https://gorillacoffee.com'
-
-# hidden due to lack of updates
-# - name: Good Life
-#   last_updated: 1/6
-#   category: food-drink
-#   social:
-#     instagram: 'https://www.instagram.com/goodlifebk/'
 
 - name: Gran Caffe De Martini
   last_updated: 1/6
@@ -1351,6 +1348,15 @@
     facebook: 'https://www.facebook.com/jamesrestaurant'
   url: 'http://www.jamesrestaurantny.com'
 
+- name: Jono Pandolfi Designs
+  category: shop
+  address: 631 Vanderbilt Ave.
+  notes: >-
+    Summer pop-up shop for this ceramics maker.
+  social:
+    instagram: 'https://www.instagram.com/jonopandolfi/'
+  url: 'https://www.jonopandolfi.com/brooklyn-popup'
+
 - name: Joy Indian
   last_updated: 1/6
   category: food-drink
@@ -1435,6 +1441,16 @@
   social:
     instagram: 'https://www.instagram.com/kimchigrill/'
   url: 'https://www.kimchigrill.com'
+
+- name: King David Tacos
+  category: food-drink
+  address: 611 Bergen Ave.
+  notes: >-
+    First brick-and-mortar retail location for King David Tacos, serving Austin-style breakfast tacos. Check their Instagram for early sell-outs.
+  social:
+    instagram: 'https://www.instagram.com/kingdavidtacos/'
+    facebook: 'https://www.facebook.com/kingdavidtacos'
+  url: 'http://kingdavidtacos.com/'
 
 - name: Kit
   last_updated: 7/2
@@ -2015,12 +2031,11 @@
   url: 'https://www.nourishthai.com'
 
 - name: The Nuaa Table
-  last_updated: 3/24
   category: food-drink
   address: 638 Bergen St.
   phone: (718) 623-6395
   notes: >-
-    New Thai restaurant at the corner of Bergen and Vanderbilt.
+    Recently opened royal Thai restaurant with a slow-food focus at the corner of Bergen and Vanderbilt.
   services:
     doordash: 'https://www.doordash.com/store/the-nuaa-table-brooklyn-1528637'
     seamless: 'https://www.seamless.com/menu/the-nuaa-table-638-bergen-st-brooklyn/2569456'
@@ -2028,6 +2043,7 @@
   social:
     instagram: 'https://www.instagram.com/thenuaatable/'
     facebook: 'https://www.facebook.com/thenuaatable/'
+  url: 'https://www.thenuaatable.com'
 
 - name: Nûrish
   last_updated: 1/6
@@ -2211,8 +2227,7 @@
     - days: Wed - Sun
       hours: 5:30 - 10PM
       span: 5
-  notes: >-
-    Reopened as of March 24.
+  # notes: >-
   links:
     - title: Oxalis Pantry
       url: 'https://www.oxalispantry.com/'
@@ -2232,6 +2247,13 @@
     instagram: 'https://www.instagram.com/oxalisnyc/'
     facebook: 'https://www.facebook.com/oxalisnyc'
   url: 'https://www.oxalisnyc.com'
+
+- name: Ozakaya
+  category: food-drink
+  notes: >-
+    Coming soon.
+  social:
+    instagram: 'https://www.instagram.com/ozakaya_nyc/'
 
 - name: Patsy’s Pizzeria
   last_updated: 1/6
@@ -2476,12 +2498,8 @@
     instagram: 'https://www.instagram.com/sharlenesbar/'
 
 - name: Sit & Wonder
-  last_updated: 1/6
+  address: 688 Washington Ave.
   category: cafe
-  hours:
-    - days: Mon - Sun
-      hours: 7:30AM - 2PM
-      span: 7
   links:
     - title: Staff Relief Fund
       url: 'https://www.gofundme.com/f/for-our-amazing-baristas'
@@ -2525,14 +2543,15 @@
   url: 'http://smokeyvale.com'
 
 - name: The Social
-  last_updated: 3/24
   address: 816 Washington Ave.
   status: closed
   category: dessert
   notes: >-
-    New ice cream shop coming this summer from the founders of Ample Hills.
+    New ice cream and doughnut shop coming this summer from the founders of Ample Hills.
   social:
-    instagram: 'https://www.instagram.com/thebrooklynicecreamsocial/'
+    instagram: 'https://www.instagram.com/thesocialbrooklyn/'
+    facebook: 'https://www.facebook.com/theSocialBrooklyn/'
+  url: 'https://www.thesocialbrooklyn.com'
 
 - name: Sofreh
   last_updated: 1/6
@@ -2776,24 +2795,14 @@
   url: 'https://underhillbrooklyn.com/'
 
 - name: Unnameable Books
-  last_updated: 1/6
   category: store
   address: 600 Vanderbilt Ave.
   phone: (718) 789-1534
-  hours:
-    - days: Mon - Thu
-      hours: 11AM - 7PM
-      span: 5
-    - days: Fri - Sat
-      hours: 11 - 9PM
-      span: 2
-    - days: Sun
-      hours: 11AM - 7PM
   links:
     - title: Online Store
       url: 'https://unnameablebooks.square.site'
   notes: >-
-    Two at a time inside.
+    Local shop that buys and sells secondhand books.
   social:
     instagram: 'https://www.instagram.com/unnameablebooks/'
     facebook: 'https://www.facebook.com/unnameable'
@@ -2804,16 +2813,9 @@
   category: dessert
   address: 550 Vanderbilt Ave
   phone: (347) 240-7453
-  hours:
-    - days: Mon - Sat
-      hours: 12 - 10PM
-      span: 7
   links:
     - title: Gift Cards
       url: 'https://squareup.com/gift/FR6ZMQGP6CJ1S/order'
-  supports:
-      - Pickup 
-      - Delivery
   services:
     caviar: 'https://www.trycaviar.com/store/van-leeuwen-ice-cream-brooklyn-773893/en-US'
     doordash: 'https://www.doordash.com/store/van-leeuwen-ice-cream-brooklyn-773893/en-US'

--- a/_data/places.yml
+++ b/_data/places.yml
@@ -1088,6 +1088,12 @@
     instagram: 'https://www.instagram.com/flatbushcounter/'
   url: 'https://www.flatbushcounter.com'
 
+- name: Foodtown
+  category: grocer
+  address: 632 Vanderbilt Ave.
+  phone: (718) 783-1887
+  url: 'https://www.foodtown.com'
+
 - name: 'Four & Twenty Blackbirds'
   last_updated: 1/6
   category: dessert
@@ -2793,6 +2799,15 @@
     instagram: 'https://www.instagram.com/underhillgreekeatery/'
     facebook: 'https://www.facebook.com/underhillbrooklyn/'
   url: 'https://underhillbrooklyn.com/'
+
+- name: Union Market
+  category: grocer
+  address: 342 Flatbush Ave.
+  phone: (718) 663-6560
+  social:
+    instagram: 'https://www.instagram.com/unionmarket/'
+    facebook: 'https://www.facebook.com/unionmarketNYC/'
+  url: 'https://unionmarket.com'
 
 - name: Unnameable Books
   category: store

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -60,7 +60,7 @@ function setModifiedDate() {
       .then((commits) => {
         var modified = commits[0]['commit']['committer']['date'].slice(0,10);
         if(modified != "{{ page.date | date: "%Y-%m-%d" }}") {
-          document.getElementById('last-modified').textContent = "Last Updated: " + modified;
+          document.getElementById('last-modified').textContent = "Last Update: " + modified;
         }
       });
   }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,6 @@
 
 <div class="w-100 pt2 bt-ns b--black-20">
-  <h2 class="f5 lh-copy tc"><a href="https://www.instagram.com/nyhospcoalition/">@nyhospcoalition</a>&#32;&bull;&#32;<a href="https://www.instagram.com/serviceworkerscoalition/">@serviceworkerscoalition</a>&#32;&bull;&#32;<a href="https://www.instagram.com/save_brooklyn/">@save_brooklyn</a>&#32;&bull;&#32;<a href="https://www.instagram.com/explore/tags/savebrooklyn/">#savebrooklyn</a></h2>
-  <p class="f7 lh-copy tc">
-    This site is <a href="{{site.github.repo}}">open source</a> and would love your contributions!
-  </p>
+  <h2 class="f5 lh-copy tc"><a href="https://www.instagram.com/nyhospcoalition/">@nyhospcoalition</a>&#32;&bull;&#32;<a href="https://www.instagram.com/serviceworkerscoalition/">@serviceworkerscoalition</a>&#32;&bull;&#32;<a href="{{site.github.repo}}">GitHub</a></h2>
 </div>
 
 <a href="{{site.github.repo}}" class="github-corner" aria-label="View source on GitHub"
@@ -53,3 +50,19 @@
     }
   }
 </style>
+<script>
+function setModifiedDate() {
+  if (document.getElementById('last-modified')) {
+    fetch("https://api.github.com/repos/{{ site.github.owner_name }}/{{ site.github.repository_name }}/commits")
+      .then((response) => {
+        return response.json();
+      })
+      .then((commits) => {
+        var modified = commits[0]['commit']['committer']['date'].slice(0,10);
+        if(modified != "{{ page.date | date: "%Y-%m-%d" }}") {
+          document.getElementById('last-modified').textContent = "Last Updated: " + modified;
+        }
+      });
+  }
+}
+</script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,17 +1,14 @@
 <div class="hero">
   <h1 class="heading-1">{{ page.title }}</h1>
 
-  <p class="text-large">
-    <a class="button" href="https://prospectheights.substack.com/subscribe">Subscribe</a> to our weekly newsletter or&nbsp;<a class="dib" href="https://prospectheights.substack.com/archive">read past isssues</a>.
-  </p>
 </div>
 
-<p class="text">
-  Our neighborhood needs <strong>your help</strong>!
-  Keep this website accurate by <a href="https://forms.gle/qZbcqvoWaNKjZExt7">contributing corrections or additions</a>,
-  and help our local businesses by donating to the <a href="https://docs.google.com/document/d/108A-_IzPjfDhLZEfTcIqkXmTzyefS3yxtCdN14Pph3s/edit?fbclid=IwAR1kBvIgOuA7b6CdxWslLK0aySLUCTwlZzWzARbBrEM6eV-yOCXmvr6op7g">Prospect Heights Small Business Relief Fund</a>
-  or the <a href="https://bit.ly/givephtips">Prospect Heights Virtual Tip Jar</a>.
+<p class="text-large">
+  This is a community resource listing local businesses and services. <br />
+  Please support businesses directly — look for this icon: <img class="br1 v-btm" src="icons/direct.png" width="24">
 </p>
 <p class="text">
-  Support businesses directly — look for this icon: <img class="br1 v-btm" src="icons/direct.png" width="24">
+  Help keep this website accurate by contributing corrections or additions via <a href="https://github.com/irace/prospectheightsbk.com/issues">GitHub</a> or our <a href="https://forms.gle/qZbcqvoWaNKjZExt7">Google Form</a>.
+  Our newsletter is inactive, but you can read <a class="dib" href="https://prospectheights.substack.com/archive">past isssues</a>.
 </p>
+<p class="text" id="last-modified"></p>

--- a/_includes/place.html
+++ b/_includes/place.html
@@ -23,6 +23,7 @@
     </div>
 
     {% unless place.status == 'closed' %}
+    
     {% if place.hours %}
     <div class="place-section">
       <h4 class="heading-4">Hours</h4>
@@ -74,8 +75,8 @@
     </div>
     {% endif %}
 
-    {% if place.last_updated %}
+    <!-- {% if place.last_updated %}
     <div class="f7 lh-copy black-40" style="margin-top: auto;">Last updated: {{ place.last_updated }}</div>
-    {% endif %}
+    {% endif %} -->
   </div>
 </div>

--- a/_includes/place.html
+++ b/_includes/place.html
@@ -18,12 +18,18 @@
         {% if place.phone %}<a class="hover-link" href="tel:{{ place.phone }}">{{ place.phone }}</a>{% endif%}
       </div>
       {% endif %}
+      {% if place.services %}
+      <div class="mt2">
+      {% for service in place.services %}
+      <a href="{{service[1]}}"><img class="service-icon" src="icons/{{service[0]}}.png" alt="{{service[0]}}" /></a>
+      {% endfor %}
+      </div>
+      {% endif %}
     <div>
       <p class="place-notes">{{ place.notes }}</p>
     </div>
 
-    {% unless place.status == 'closed' %}
-    
+    {% comment %}
     {% if place.hours %}
     <div class="place-section">
       <h4 class="heading-4">Hours</h4>
@@ -52,16 +58,9 @@
         {% endfor %}
       </ul>
       {% endif %}
-      
-      {% if place.services %}
-      <h5 class="heading-5">Online Ordering</h5>
-      {% for service in place.services %}
-      <a href="{{service[1]}}"><img class="service-icon" src="icons/{{service[0]}}.png" alt="{{service[0]}}" /></a>
-      {% endfor %}
-      {% endif %}
     </div>
     {% endif %}
-    {% endunless %}
+    {% endcomment %}
 
     {% if place.links %}
     <div class="place-section">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 <head>
 {% include head.html %}
 </head>
-<body id="top" class="typography">
+<body id="top" class="typography" onload="setModifiedDate();">
 <header class="wrapper fw5">
 {% include header.html %}
 </header>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,11 @@ layout: default
 <nav>
   <span class="heading-4">Jump to: </span>
   <ul class="list pl0 mv2">
-    {% for category in categories %}
-    <li class="dib mr2"><a href="#{{category.name}}">{{category.heading}}</a></li>
+  {% for category in categories %}
+    {% assign category_places = places | where: "category", category.name %}
+    {% unless category_places == empty %}
+      <li class="dib mr2"><a href="#{{category.name}}">{{category.heading}}</a></li>
+    {% endunless %}
   {% endfor %}
     <li class="dib mr2"><a href="#directory">Full Directory</a></li>
   </ul>
@@ -19,7 +22,7 @@ layout: default
 {% for category in categories %}
 <section id="{{ category.name }}" class="section">
   {% assign category_places = places | where: "category", category.name %}
-
+  {% unless category_places == empty %}
   <div class="section-heading">
     <h2 class="heading-2">{{ category.heading }}</h2>
     <a href="#top" class="back-to-top">↑</a>
@@ -27,6 +30,7 @@ layout: default
   {% for place in category_places %}
     {% include place.html %}
   {% endfor %}
+  {% endunless %}
 
 </section>
 {% endfor %}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@ layout: default
   {% endfor %}
     <li class="dib mr2"><a href="#directory">Full Directory</a></li>
   </ul>
-  
 </nav>
 
 {% for category in categories %}
@@ -38,6 +37,8 @@ layout: default
     <a href="#top" class="back-to-top">↑</a>
   </div>
   {% for place in places %}
+    {% unless place.category == "a1" %}
     {% include place_mini.html %}
+    {% endunless %}
   {% endfor %}
 </section>

--- a/styles.scss
+++ b/styles.scss
@@ -149,10 +149,12 @@ a {
     @extend .flex, .justify-between;
   }
   .place-notes {
+    
     @extend .fw5, .mt3, .mb2;
   }
 
   .place-section {
+    display: none;
     @extend .mt1, .pt1, .mv2, .bt, .b--black-10;
 
     .heading-4 {

--- a/styles.scss
+++ b/styles.scss
@@ -154,7 +154,6 @@ a {
   }
 
   .place-section {
-    display: none;
     @extend .mt1, .pt1, .mv2, .bt, .b--black-10;
 
     .heading-4 {


### PR DESCRIPTION
Cleanup and simplification. Since the last PR this spring, the city has majorly changed and I want to make sure this repo is still relevant in some capacity going forward.

<img width="1366" alt="IMG_2075" src="https://user-images.githubusercontent.com/868532/124342073-1e4b7500-db8f-11eb-9a0f-ce775d9361ca.png">

(Why is the “updated date” saying March? See below.)

## Added

- Prospect Heights NDC and North Flatbush BID. These seemed like important organizations we weren’t linking to, as the former is responsible for the neighborhood open streets. The latter straddles between Prospect Heights and Park Slope and is a critical partner to businesses along the corridor.
- New contribution suggestions. I’m also going to open an issue to suggest issue templates, which may make more sense if there are any future updates anyone wants to provide.
- New businesses. Flatbush Counter and Tiny’s Cantina are now open, and now we’ve got Dough and Kit. Also added Finn’s Corner, which was missing.
- A new deli / bodega category for future use.
- There’s a new, dynamic last-updated date at the top of the page thanks to @ryanfb’s [helpful post](https://ryanfb.github.io/etc/2020/04/27/last_modified_dates_for_github_pages_jekyll_posts.html)

## Changed and removed
- Hours and the How to Support sections of place listings had become unmanageable. I’ve commented them out for now, but they should eventually be removed along with their data.
- Speaking of which, and considering the dynamic last-updated date, I’ve removed the update date from the place template, and have started removing some data.
- Closed businesses: Kulushkat (still open in Prospect Lefferts!), Chick-P (Bergen Pizza next door was somehow never on the list), Washington Ave. Cafe. I also removed Dough Studio, whose Instagram hasn’t been updated in nearly a year.